### PR TITLE
Add waiting-input browser notifications with session deep-link

### DIFF
--- a/crates/forgehub/src/db.rs
+++ b/crates/forgehub/src/db.rs
@@ -220,6 +220,25 @@ pub async fn list_replay_events(
     rows.into_iter().map(replay_event_from_row).collect()
 }
 
+pub async fn latest_replay_event(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> anyhow::Result<Option<ReplayEvent>> {
+    let row = sqlx::query_as::<_, ReplayEventRow>(
+        r#"
+        SELECT id, session_id, repo_id, timestamp, elapsed, event_type, action, result, payload
+        FROM replay_events
+        WHERE session_id = ?
+        ORDER BY id DESC
+        LIMIT 1
+        "#,
+    )
+    .bind(session_id)
+    .fetch_optional(pool)
+    .await?;
+    row.map(replay_event_from_row).transpose()
+}
+
 pub async fn ensure_workspace(pool: &SqlitePool, workspace_id: &str) -> anyhow::Result<()> {
     let org_id = "org-default";
     sqlx::query("INSERT OR IGNORE INTO organizations (id, name) VALUES (?, ?)")

--- a/crates/forgehub/src/lib.rs
+++ b/crates/forgehub/src/lib.rs
@@ -18,8 +18,9 @@ mod db;
 mod risk;
 use db::{
     decision_count, ensure_workspace, get_decision, get_workspace, init_db, insert_decision,
-    insert_replay_event, list_decisions, list_replay_events, list_workspaces, log_budget_action,
-    mark_edge_sessions_unreachable, resolve_decision, seed_workspaces, upsert_session_cache,
+    insert_replay_event, latest_replay_event, list_decisions, list_replay_events, list_workspaces,
+    log_budget_action, mark_edge_sessions_unreachable, resolve_decision, seed_workspaces,
+    upsert_session_cache,
 };
 use risk::compute_risk;
 
@@ -490,6 +491,14 @@ impl HubService {
             None
         };
         Ok((events, next_cursor))
+    }
+
+    #[instrument(skip(self))]
+    pub async fn latest_replay_event(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<Option<ReplayEvent>> {
+        latest_replay_event(&self.db, session_id).await
     }
 
     fn next_decision_id(&self) -> String {

--- a/crates/forgehub/src/main.rs
+++ b/crates/forgehub/src/main.rs
@@ -1359,7 +1359,10 @@ async fn replay_latest(
     }
     match service.latest_replay_event(&id).await {
         Ok(Some(event)) => (axum::http::StatusCode::OK, Json(event)).into_response(),
-        Ok(None) => (axum::http::StatusCode::NOT_FOUND, Json(serde_json::json!({})))
+        Ok(None) => (
+            axum::http::StatusCode::NOT_FOUND,
+            Json(serde_json::json!({})),
+        )
             .into_response(),
         Err(err) => (
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/forgehub/src/main.rs
+++ b/crates/forgehub/src/main.rs
@@ -149,6 +149,7 @@ fn main() -> anyhow::Result<()> {
                 .route("/sessions/:id/input", post(session_input))
                 .route("/sessions/:id/usage", get(session_usage))
                 .route("/sessions/:id/replay/timeline", get(replay_timeline))
+                .route("/sessions/:id/replay/latest", get(replay_latest))
                 .route("/sessions/:id/replay/diff", get(replay_diff))
                 .route("/sessions/:id/replay/terminal", get(replay_terminal))
                 .route("/foreman/report", get(foreman_report))
@@ -1332,6 +1333,33 @@ async fn replay_timeline(
             axum::http::StatusCode::OK,
             Json(serde_json::json!({ "events": events, "next_cursor": next_cursor })),
         )
+            .into_response(),
+        Err(err) => (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": err.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+async fn replay_latest(
+    State(service): State<Arc<HubService>>,
+    headers: HeaderMap,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> impl IntoResponse {
+    if let Some(resp) = check_version(&headers) {
+        return resp;
+    }
+    if !authorized(&service, &headers, None) {
+        return (
+            axum::http::StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({ "error": "unauthorized" })),
+        )
+            .into_response();
+    }
+    match service.latest_replay_event(&id).await {
+        Ok(Some(event)) => (axum::http::StatusCode::OK, Json(event)).into_response(),
+        Ok(None) => (axum::http::StatusCode::NOT_FOUND, Json(serde_json::json!({})))
             .into_response(),
         Err(err) => (
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1,5 +1,5 @@
 import { h, render } from "./lib/preact.module.js";
-import { useEffect, useMemo, useState } from "./lib/hooks.module.js";
+import { useEffect, useMemo, useRef, useState } from "./lib/hooks.module.js";
 import htm from "./lib/htm.module.js";
 import { TopNav } from "./components/nav.js";
 import { FleetDashboard } from "./components/fleet.js";
@@ -11,6 +11,21 @@ import { api } from "./services/api.js";
 import { connectWS } from "./services/ws.js";
 
 const html = htm.bind(h);
+
+function repoFromPath(path) {
+  if (!path) return "";
+  const parts = path.split("/").filter(Boolean);
+  return parts[parts.length - 1] || path;
+}
+
+function sessionLabel(session) {
+  return session?.name || repoFromPath(session?.repo_root) || session?.goal || session?.id || "session";
+}
+
+function isWaitingState(state) {
+  const value = (state || "").toLowerCase();
+  return value === "waitinginput" || value === "waiting_input" || value === "waiting";
+}
 
 function useHashRoute(defaultView = "fleet") {
   const [view, setView] = useState(() => window.location.hash.replace("#", "") || defaultView);
@@ -62,6 +77,19 @@ function App() {
   const [workspaces, setWorkspaces] = useState([]);
   const [workspaceId, setWorkspaceId] = useState(baseWorkspace.id);
   const [workspace, setWorkspace] = useState(baseWorkspace);
+  const lastStatesRef = useRef(new Map());
+  const notifiedRef = useRef(new Set());
+
+  const openAttachForSession = (sessionId) => {
+    if (!sessionId) return;
+    try {
+      localStorage.setItem("forgemux_attach_session", sessionId);
+    } catch {
+      // ignore
+    }
+    setAttachSessionId(sessionId);
+    setView("attach");
+  };
 
   useEffect(() => {
     api
@@ -88,6 +116,88 @@ function App() {
     });
     return () => stop();
   }, [workspaceId]);
+
+  useEffect(() => {
+    const key = "forgemux_attach_session";
+    const readPending = () => {
+      try {
+        return localStorage.getItem(key);
+      } catch {
+        return null;
+      }
+    };
+    const pending = readPending();
+    if (pending) {
+      openAttachForSession(pending);
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        // ignore
+      }
+    }
+    const onStorage = (event) => {
+      if (event.key !== key) return;
+      if (event.newValue) {
+        openAttachForSession(event.newValue);
+        try {
+          localStorage.removeItem(key);
+        } catch {
+          // ignore
+        }
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  useEffect(() => {
+    const notifyWaiting = async (session) => {
+      if (typeof Notification === "undefined") return;
+      let permission = Notification.permission;
+      if (permission === "default") {
+        try {
+          permission = await Notification.requestPermission();
+        } catch {
+          return;
+        }
+      }
+      if (permission !== "granted") return;
+
+      let detail = session.goal || "";
+      try {
+        const event = await api.replayLatest(session.id);
+        if (event?.action) {
+          detail = event.result ? `${event.action} — ${event.result}` : event.action;
+        }
+      } catch {
+        // ignore
+      }
+
+      const title = `Waiting for input: ${sessionLabel(session)}`;
+      const body = detail || `${session.agent || "agent"} · ${session.model || "model"}`;
+      const notification = new Notification(title, { body });
+      notification.onclick = () => {
+        try {
+          window.focus();
+        } catch {
+          // ignore
+        }
+        openAttachForSession(session.id);
+      };
+    };
+
+    sessions.forEach((session) => {
+      const prev = lastStatesRef.current.get(session.id);
+      const next = session.state;
+      lastStatesRef.current.set(session.id, next);
+      if (!isWaitingState(next)) return;
+      const key = `${session.id}:${next}`;
+      if (notifiedRef.current.has(key)) return;
+      if (prev && prev === next) return;
+      notifiedRef.current.add(key);
+      notifyWaiting(session);
+    });
+  }, [sessions]);
 
   useEffect(() => {
     api
@@ -254,8 +364,7 @@ function App() {
   };
 
   const attachSession = (id) => {
-    setAttachSessionId(id);
-    setView("attach");
+    openAttachForSession(id);
   };
 
   const orgLabel = workspace.org || workspace.org_id || baseWorkspace.org;

--- a/dashboard/services/api.js
+++ b/dashboard/services/api.js
@@ -77,6 +77,9 @@ export const api = {
     const suffix = qs.toString();
     return fetchJSON(`/sessions/${sessionId}/replay/timeline${suffix ? `?${suffix}` : ""}`);
   },
+  replayLatest(sessionId) {
+    return fetchJSON(`/sessions/${sessionId}/replay/latest`);
+  },
   replayDiff(sessionId) {
     return fetchJSON(`/sessions/${sessionId}/replay/diff`);
   },


### PR DESCRIPTION
## Summary
- add browser OS notifications when a session enters `WaitingInput`
- include latest replay action/result in the notification body so users can see what the agent just did
- make notification click open the dashboard Attach view for that exact session
- add `/sessions/:id/replay/latest` endpoint and dashboard client support

## Testing
- `cargo test -p forgehub --test bdd`
- pre-push hook: `cargo test --workspace`

Fixes #4
